### PR TITLE
Adds ignore rules for specific deps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,13 @@ updates:
           - "*"
     versioning-strategy: increase
     open-pull-requests-limit: 1
+    ignore:
+      # @actions v3.x packages are pure ESM and incompatible with @vercel/ncc
+      - dependency-name: "@actions/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@actions/exec"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@actions/io"
+        update-types: ["version-update:semver-major"]
+      # Node types should be updated manually to match target runtime
+      - dependency-name: "@types/node"


### PR DESCRIPTION
Configure Dependabot to ignore:

- @actions packages v3.x - These are pure ESM modules incompatible with @vercel/ncc bundler
- @types/node - Should be updated manually to match GitHub Actions runtime

This prevents build failures like the one in #22 where v3.x @actions packages caused module resolution errors during the ncc build step.